### PR TITLE
Pin buildah-build to v2.13 to avoid parallel multi-arch builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Build Image
         id: build_image
-        uses: redhat-actions/buildah-build@v3
+        uses: redhat-actions/buildah-build@v2.13
         with:
           image: ${{ github.event.repository.name }}
           tags: ${{ github.event_name == 'pull_request' && github.sha || (github.ref_name == 'main' && 'latest' || github.ref_name) }}


### PR DESCRIPTION
v3 builds all archs concurrently via qemu emulation, overloading the GitHub runner. v2.13 predates that change and builds archs serially.